### PR TITLE
Add route /auth/state

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -185,7 +185,7 @@ module ApplicationHelper
     text.split("\n").map { |line| "> #{line}" }.join("\n")
   end
 
-  def render_initial_state
+  def generate_initial_state_json
     state_params = {
       settings: {},
       text: [params[:title], params[:text], params[:url]].compact.join(' '),
@@ -211,7 +211,11 @@ module ApplicationHelper
 
     state_params[:owner] = Account.local.without_suspended.without_internal.first if single_user_mode?
 
-    json = ActiveModelSerializers::SerializableResource.new(InitialStatePresenter.new(state_params), serializer: InitialStateSerializer).to_json
+    ActiveModelSerializers::SerializableResource.new(InitialStatePresenter.new(state_params), serializer: InitialStateSerializer).to_json
+  end
+
+  def render_initial_state
+    json = generate_initial_state_json
     # rubocop:disable Rails/OutputSafety
     content_tag(:script, json_escape(json).html_safe, id: 'initial-state', type: 'application/json')
     # rubocop:enable Rails/OutputSafety

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,6 +101,7 @@ Rails.application.routes.draw do
       resource :setup, only: [:show, :update], controller: :setup
       resource :challenge, only: [:create]
       get 'sessions/security_key_options', to: 'sessions#webauthn_options'
+      get 'state', to: 'sessions#state'
       post 'captcha_confirmation', to: 'confirmations#confirm_captcha', as: :captcha_confirmation
     end
   end


### PR DESCRIPTION
This pr adds the route /auth/state which returns the state for a session. The purpose is to allow for accessing the state for frontent apps via ajax.