### PR TITLE
Update Docker Build Workflows

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -1,8 +1,7 @@
-name: Build nightly container image
+name: Build container image for main branch
 on:
-  workflow_dispatch:
-  schedule:
-    - cron: '0 2 * * *' # run at 2 AM UTC
+  push:
+    branches: ['main']
 
 permissions:
   contents: read

--- a/.github/workflows/build-releases.yml
+++ b/.github/workflows/build-releases.yml
@@ -14,8 +14,7 @@ jobs:
     with:
       file_to_build: Dockerfile
       push_to_images: |
-        tootsuite/mastodon
-        ghcr.io/mastodon/mastodon
+        ghcr.io/fediway/mastodon
       # Do not use cache when building releases, so apt update is always ran and the release always contain the latest packages
       cache: false
       # Only tag with latest when ran against the latest stable branch

--- a/.github/workflows/build-security.yml
+++ b/.github/workflows/build-security.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   compute-suffix:
     runs-on: ubuntu-latest
-    if: github.repository == 'mastodon/mastodon'
+    if: github.repository == 'fediway/mastodon'
     steps:
       - id: version_vars
         env:
@@ -26,28 +26,7 @@ jobs:
       file_to_build: Dockerfile
       cache: false
       push_to_images: |
-        tootsuite/mastodon
-        ghcr.io/mastodon/mastodon
-      version_prerelease: ${{ needs.compute-suffix.outputs.prerelease }}
-      labels: |
-        org.opencontainers.image.description=Nightly build image used for testing purposes
-      flavor: |
-        latest=auto
-      tags: |
-        type=raw,value=edge
-        type=raw,value=nightly
-        type=raw,value=${{ needs.compute-suffix.outputs.prerelease }}
-    secrets: inherit
-
-  build-image-streaming:
-    needs: compute-suffix
-    uses: ./.github/workflows/build-container-image.yml
-    with:
-      file_to_build: streaming/Dockerfile
-      cache: false
-      push_to_images: |
-        tootsuite/mastodon-streaming
-        ghcr.io/mastodon/mastodon-streaming
+        ghcr.io/fediway/mastodon
       version_prerelease: ${{ needs.compute-suffix.outputs.prerelease }}
       labels: |
         org.opencontainers.image.description=Nightly build image used for testing purposes


### PR DESCRIPTION
This pr updates docker build workflows to push to `ghcr.io/fediway/mastodon`.

Also the streaming build was removed, as I dont plan to make any modifications on the streaming service.