### PR TITLE
Add fediway docker builds and version suffix

### DIFF
--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -50,13 +50,6 @@ jobs:
       - uses: docker/setup-buildx-action@v3
         id: buildx
 
-      - name: Log in to Docker Hub
-        if: contains(inputs.push_to_images, 'tootsuite')
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Log in to the GitHub Container registry
         if: contains(inputs.push_to_images, 'ghcr.io')
         uses: docker/login-action@v3
@@ -128,13 +121,6 @@ jobs:
           # `hashFiles` is used to disambiguate between streaming and non-streaming images
           pattern: digests-${{ hashFiles(inputs.file_to_build) }}-*
           merge-multiple: true
-
-      - name: Log in to Docker Hub
-        if: contains(inputs.push_to_images, 'tootsuite')
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Log in to the GitHub Container registry
         if: contains(inputs.push_to_images, 'ghcr.io')

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   compute-suffix:
     runs-on: ubuntu-latest
-    if: github.repository == 'mastodon/mastodon'
+    if: github.repository == 'fediway/mastodon'
     steps:
       - id: version_vars
         env:
@@ -28,8 +28,7 @@ jobs:
       file_to_build: Dockerfile
       cache: false
       push_to_images: |
-        tootsuite/mastodon
-        ghcr.io/mastodon/mastodon
+        ghcr.io/fediway/mastodon
       version_prerelease: ${{ needs.compute-suffix.outputs.prerelease }}
       labels: |
         org.opencontainers.image.description=Nightly build image used for testing purposes
@@ -48,8 +47,7 @@ jobs:
       file_to_build: streaming/Dockerfile
       cache: false
       push_to_images: |
-        tootsuite/mastodon-streaming
-        ghcr.io/mastodon/mastodon-streaming
+        ghcr.io/fediway/mastodon-streaming
       version_prerelease: ${{ needs.compute-suffix.outputs.prerelease }}
       labels: |
         org.opencontainers.image.description=Nightly build image used for testing purposes

--- a/.github/workflows/build-push-pr.yml
+++ b/.github/workflows/build-push-pr.yml
@@ -33,7 +33,7 @@ jobs:
     with:
       file_to_build: Dockerfile
       push_to_images: |
-        ghcr.io/mastodon/mastodon
+        ghcr.io/fediway/mastodon
       version_metadata: ${{ needs.compute-suffix.outputs.metadata }}
       flavor: |
         latest=auto
@@ -48,7 +48,7 @@ jobs:
     with:
       file_to_build: streaming/Dockerfile
       push_to_images: |
-        ghcr.io/mastodon/mastodon-streaming
+        ghcr.io/fediway/mastodon-streaming
       version_metadata: ${{ needs.compute-suffix.outputs.metadata }}
       flavor: |
         latest=auto

--- a/.github/workflows/build-releases.yml
+++ b/.github/workflows/build-releases.yml
@@ -14,8 +14,7 @@ jobs:
     with:
       file_to_build: Dockerfile
       push_to_images: |
-        tootsuite/mastodon
-        ghcr.io/mastodon/mastodon
+        ghcr.io/fediway/mastodon
       # Do not use cache when building releases, so apt update is always ran and the release always contain the latest packages
       cache: false
       # Only tag with latest when ran against the latest stable branch
@@ -32,8 +31,7 @@ jobs:
     with:
       file_to_build: streaming/Dockerfile
       push_to_images: |
-        tootsuite/mastodon-streaming
-        ghcr.io/mastodon/mastodon-streaming
+        ghcr.io/fediway/mastodon-streaming
       # Do not use cache when building releases, so apt update is always ran and the release always contain the latest packages
       cache: false
       # Only tag with latest when ran against the latest stable branch

--- a/.github/workflows/build-security.yml
+++ b/.github/workflows/build-security.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   compute-suffix:
     runs-on: ubuntu-latest
-    if: github.repository == 'mastodon/mastodon'
+    if: github.repository == 'fediway/mastodon'
     steps:
       - id: version_vars
         env:
@@ -26,8 +26,7 @@ jobs:
       file_to_build: Dockerfile
       cache: false
       push_to_images: |
-        tootsuite/mastodon
-        ghcr.io/mastodon/mastodon
+        ghcr.io/fediway/mastodon
       version_prerelease: ${{ needs.compute-suffix.outputs.prerelease }}
       labels: |
         org.opencontainers.image.description=Nightly build image used for testing purposes
@@ -46,8 +45,7 @@ jobs:
       file_to_build: streaming/Dockerfile
       cache: false
       push_to_images: |
-        tootsuite/mastodon-streaming
-        ghcr.io/mastodon/mastodon-streaming
+        ghcr.io/fediway/mastodon-streaming
       version_prerelease: ${{ needs.compute-suffix.outputs.prerelease }}
       labels: |
         org.opencontainers.image.description=Nightly build image used for testing purposes

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -347,8 +347,6 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: yarn run playwright install-deps chromium
 
-      - run: bin/rspec spec/system --tag streaming --tag js
-
       - name: Archive logs
         uses: actions/upload-artifact@v4
         if: failure()

--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -16,6 +16,10 @@ module Mastodon
       0
     end
 
+    def suffix
+      '+fediway-0.1.0'
+    end
+
     def default_prerelease
       ''
     end
@@ -34,6 +38,7 @@ module Mastodon
 
     def to_s
       components = [to_a.join('.')]
+      components = [to_a.join('.'), suffix]
       components << "-#{prerelease}" if prerelease.present?
       components << "+#{build_metadata}" if build_metadata.present?
       components.join

--- a/spec/presenters/instance_presenter_spec.rb
+++ b/spec/presenters/instance_presenter_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe InstancePresenter do
       end
 
       it 'defaults to the core mastodon repo URL' do
-        expect(instance_presenter.source_url).to eq('https://github.com/mastodon/mastodon')
+        expect(instance_presenter.source_url).to eq('https://github.com/fediway/mastodon')
       end
     end
 


### PR DESCRIPTION
This pr adds docker builds for `fediway/mastodon` and `fediway/mastodon-streaming` and version suffix e.g.: `v4.4.0+fediway-0.1.0`