### PR TITLE
Add SSO bridge to convert bearer token to Devise session

### DIFF
--- a/FEDIWAY.md
+++ b/FEDIWAY.md
@@ -7,6 +7,7 @@ Fork of [Mastodon](https://github.com/mastodon/mastodon), maintained at https://
 Fediway-specific behavior is feature-flagged. With every flag unset, the fork is byte-compatible with upstream Mastodon.
 
 - **`FEDIWAY_AUTH_DIRECT=true`** — enables OAuth 2.0 password grant ([RFC 6749 §4.3](https://datatracker.ietf.org/doc/html/rfc6749#section-4.3)) on the existing `/oauth/token` endpoint. POST `{grant_type: password, username, password, client_id, scope}` returns a bearer token without the OAuth redirect dance. 2FA users are rejected — the redirect-based flow remains the path for them. Mastodon's existing OAuth code-exchange flow is unchanged whether the flag is set or not.
+- **`POST /api/fediway/v1/sessions/bridge`** — additive endpoint. Takes a valid `Authorization: Bearer <token>` and creates a Devise session cookie for the same user. Lets a single Fediway-frontend login give access to both the JSON API (via the bearer token) and the server-rendered admin / settings pages (via the session cookie), without requiring a second sign-in. No env flag — the endpoint exists whenever the fork is deployed, harmless when unused.
 - **`FEDIWAY_WEB_URL=<url>`** — Mastodon's React SPA routes redirect to this URL. The SPA serves unchanged when unset.
 
 ## Runtime version identification

--- a/app/controllers/api/fediway/v1/sessions_controller.rb
+++ b/app/controllers/api/fediway/v1/sessions_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# FEDIWAY: SSO bridge — exchange a Doorkeeper bearer token for a Devise session cookie
+class Api::Fediway::V1::SessionsController < Api::BaseController
+  skip_forgery_protection only: :bridge
+  before_action -> { doorkeeper_authorize! }
+  before_action :require_user!
+
+  def bridge
+    sign_in current_user
+    render_empty
+  end
+end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -371,4 +371,11 @@ namespace :api, format: false do
     resources :embeds, only: [:show]
     resources :push_subscriptions, only: [:create, :destroy, :update]
   end
+
+  # FEDIWAY: SSO bridge — exchange a Doorkeeper bearer token for a Devise session
+  namespace :fediway do
+    namespace :v1 do
+      post 'sessions/bridge', to: 'sessions#bridge'
+    end
+  end
 end

--- a/spec/requests/api/fediway/v1/sessions_spec.rb
+++ b/spec/requests/api/fediway/v1/sessions_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Fediway sessions bridge' do
+  describe 'POST /api/fediway/v1/sessions/bridge' do
+    subject { post '/api/fediway/v1/sessions/bridge', headers: headers }
+
+    let(:user) { Fabricate(:user) }
+    let(:application) { Fabricate(:application) }
+    let(:token) { Fabricate(:accessible_access_token, application: application, resource_owner_id: user.id, scopes: 'read') }
+    let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
+
+    context 'without a token' do
+      let(:headers) { {} }
+
+      it 'returns 401' do
+        subject
+        expect(response).to have_http_status(401)
+      end
+    end
+
+    context 'with a valid token' do
+      it 'returns 200' do
+        subject
+        expect(response).to have_http_status(200)
+      end
+
+      it 'sets a session cookie' do
+        subject
+        expect(response.headers['Set-Cookie'].to_s).to include('session')
+      end
+    end
+
+    context 'when the user is disabled' do
+      before { user.update!(disabled: true) }
+
+      it 'returns 403' do
+        subject
+        expect(response).to have_http_status(403)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds POST /api/fediway/v1/sessions/bridge — given a valid Doorkeeper bearer
token in the Authorization header, calls Devise's sign_in to write a session
cookie for the same user. This lets a single Fediway-frontend login give
access to both:

- The JSON API (/api/v1/*) via the bearer token, AND
- Server-rendered admin / settings pages (/admin/*, /settings) via the session

Without this, admins logged in via password grant would have to sign in a
second time at /auth/sign_in to access /admin/*. With it, clicking "Manage
Instance" in the Fediway frontend goes straight to /admin with no extra login.

Files:
- app/controllers/api/fediway/v1/sessions_controller.rb (new, ~10 lines)
- config/routes/api.rb (one marked addition at end)
- spec/requests/api/fediway/v1/sessions_spec.rb (new, 4 tests)
- FEDIWAY.md (documented the new endpoint)

Locally verified: 17 examples (4 new + 13 existing oauth/token), 0 failures.